### PR TITLE
Android security 11.0.0 release 64

### DIFF
--- a/lib/xmlparse.c
+++ b/lib/xmlparse.c
@@ -970,6 +970,14 @@ parserCreate(const XML_Char *encodingName,
   parserInit(parser, encodingName);
 
   if (encodingName && ! parser->m_protocolEncodingName) {
+    if (dtd) {
+      // We need to stop the upcoming call to XML_ParserFree from happily
+      // destroying parser->m_dtd because the DTD is shared with the parent
+      // parser and the only guard that keeps XML_ParserFree from destroying
+      // parser->m_dtd is parser->m_isParamEntity but it will be set to
+      // XML_TRUE only later in XML_ExternalEntityParserCreate (or not at all).
+      parser->m_dtd = NULL;
+    }
     XML_ParserFree(parser);
     return NULL;
   }


### PR DESCRIPTION
Merge tag 'android-security-11.0.0_r64' of https://android.googlesource.com/platform/external/expat into arrow-11.0

Android security 11.0.0 release 64
Tag: https://android.googlesource.com/platform/external/expat/+/refs/tags/android-security-11.0.0_r64

Merge cherrypicks of ['ag/20497949'] into security-aosp-rvc-release.

Change-Id: [I2d99ce0c287f8d011a349b34b529d1f327b88c5c](https://android-review.googlesource.com/#/q/I2d99ce0c287f8d011a349b34b529d1f327b88c5c)